### PR TITLE
Simplify transition to new stencil format. Now, just need to rename .…

### DIFF
--- a/src/compiler/Makefile
+++ b/src/compiler/Makefile
@@ -96,10 +96,12 @@ PYINC		:= 	$(addprefix -I,$(shell $(PYTHON) -c 'import distutils.sysconfig; prin
 RUN_PYTHON	:= 	env PYTHONPATH=$(LIB_DIR):$(YASK_DIR):$(PYTHONPATH) $(PYTHON)
 
 # Compile rules.
-# Build stencils at O0 to avoid C++ compiler wasting time optimizing them.
+# For example stencils,
+# - Build at O0 to avoid C++ compiler wasting time optimizing them.
+# - Set macro to use internal DSL instead of conflicting API operators.
 
 $(STENCIL_DIR)/%.o: $(STENCIL_DIR)/%.cpp $(YC_INC_GLOB)
-	$(CXX_PREFIX) $(YC_CXX) $(YC_CXXFLAGS) -O0 -fPIC -c -o $@ $<
+	$(CXX_PREFIX) $(YC_CXX) $(YC_CXXFLAGS) -DUSE_INTERNAL_DSL -O0 -fPIC -c -o $@ $<
 	@ls -l $@
 
 %.o: %.cpp $(YC_INC_GLOB)
@@ -205,7 +207,7 @@ all:
 	$(MAKE) all-tests
 
 old-code-check: $(wildcard $(STENCIL_DIR)/*Stencil.hpp)
-	@ for i in $^; do echo "*** WARNING: '$$i' should now be a .cpp file. If unmodified, please delete. If modified or new, please add '#define USE_INTERNAL_DSL' to source and rename to .cpp."; done
+	@ for i in $^; do echo "*** WARNING: '$$i' detected. Stencils should now be in .cpp files. If this file is unmodified, just delete it. If modified or new, change its suffix to .cpp."; done
 
 # Remove intermediate files.
 clean:

--- a/src/stencils/AwpElasticStencil.cpp
+++ b/src/stencils/AwpElasticStencil.cpp
@@ -44,11 +44,6 @@ IN THE SOFTWARE.
 // Set the following macro to use intermediate scratch grids.
 //#define USE_SCRATCH_GRIDS
 
-// This macro blocks the operator overloads in the API.
-// This is temporary until the "internal DSL" gets completely
-// replaced by the APIs.
-#define USE_INTERNAL_DSL
-
 #include "Soln.hpp"
 
 class AwpElasticStencil : public StencilBase {

--- a/src/stencils/AwpStencil.cpp
+++ b/src/stencils/AwpStencil.cpp
@@ -30,11 +30,6 @@ IN THE SOFTWARE.
 // Set the following macro to use a sponge grid instead of 3 sponge arrays.
 //#define FULL_SPONGE_GRID
 
-// This macro blocks the operator overloads in the API.
-// This is temporary until the "internal DSL" gets completely
-// replaced by the APIs.
-#define USE_INTERNAL_DSL
-
 #include "Soln.hpp"
 
 class AwpStencil : public StencilBase {

--- a/src/stencils/ExampleStencil.cpp
+++ b/src/stencils/ExampleStencil.cpp
@@ -26,11 +26,6 @@ IN THE SOFTWARE.
 // Implement various example symmetric 3D stencil shapes that read and
 // write from only one 3D grid.
 
-// This macro blocks the operator overloads in the API.
-// This is temporary until the "internal DSL" gets completely
-// replaced by the APIs.
-#define USE_INTERNAL_DSL
-
 #include "Soln.hpp"
 
 class ExampleStencil : public StencilRadiusBase {

--- a/src/stencils/FSGElastic2Stencil.cpp
+++ b/src/stencils/FSGElastic2Stencil.cpp
@@ -26,11 +26,6 @@ IN THE SOFTWARE.
 // Stencil equations for FSG elastic numerics.
 // Contributed by Albert Farres from the Barcelona Supercomputing Center
 
-// This macro blocks the operator overloads in the API.
-// This is temporary until the "internal DSL" gets completely
-// replaced by the APIs.
-#define USE_INTERNAL_DSL
-
 #include "Soln.hpp"
 #include "ElasticStencil/Elastic2Stencil.hpp"
 

--- a/src/stencils/FSGElasticStencil.cpp
+++ b/src/stencils/FSGElasticStencil.cpp
@@ -26,11 +26,6 @@ IN THE SOFTWARE.
 // Stencil equations for FSG elastic numerics.
 // Contributed by Albert Farres from the Barcelona Supercomputing Center
 
-// This macro blocks the operator overloads in the API.
-// This is temporary until the "internal DSL" gets completely
-// replaced by the APIs.
-#define USE_INTERNAL_DSL
-
 #include "Soln.hpp"
 #include "ElasticStencil/ElasticStencil.hpp"
 

--- a/src/stencils/Iso3dfdStencil.cpp
+++ b/src/stencils/Iso3dfdStencil.cpp
@@ -26,11 +26,6 @@ IN THE SOFTWARE.
 // Implement isotropic 3D finite-difference (FD) stencil, nth-order accurate in
 // space (where n = 2 * radius) and 2nd-order accurate in time.
 
-// This macro blocks the operator overloads in the API.
-// This is temporary until the "internal DSL" gets completely
-// replaced by the APIs.
-#define USE_INTERNAL_DSL
-
 #include "Soln.hpp"
 
 class Iso3dfdStencil : public StencilRadiusBase {

--- a/src/stencils/SSGElastic2Stencil.cpp
+++ b/src/stencils/SSGElastic2Stencil.cpp
@@ -25,11 +25,6 @@ IN THE SOFTWARE.
 
 // Stencil equations for SSG elastic numerics.
 
-// This macro blocks the operator overloads in the API.
-// This is temporary until the "internal DSL" gets completely
-// replaced by the APIs.
-#define USE_INTERNAL_DSL
-
 #include "ElasticStencil/Elastic2Stencil.hpp"
 
 class SSGElastic2Stencil : public Elastic2StencilBase {

--- a/src/stencils/SSGElasticStencil.cpp
+++ b/src/stencils/SSGElasticStencil.cpp
@@ -25,11 +25,6 @@ IN THE SOFTWARE.
 
 // Stencil equations for SSG elastic numerics.
 
-// This macro blocks the operator overloads in the API.
-// This is temporary until the "internal DSL" gets completely
-// replaced by the APIs.
-#define USE_INTERNAL_DSL
-
 #include "ElasticStencil/ElasticStencil.hpp"
 
 class SSGElasticStencil : public ElasticStencilBase {

--- a/src/stencils/SimpleTestStencils.cpp
+++ b/src/stencils/SimpleTestStencils.cpp
@@ -25,11 +25,6 @@ IN THE SOFTWARE.
 
 // Some very simple tests.
 
-// This macro blocks the operator overloads in the API.
-// This is temporary until the "internal DSL" gets completely
-// replaced by the APIs.
-#define USE_INTERNAL_DSL
-
 #include "Soln.hpp"
 
 // Simple tests to increment values in N spatial dims.

--- a/src/stencils/TTIStencil.cpp
+++ b/src/stencils/TTIStencil.cpp
@@ -26,11 +26,6 @@ IN THE SOFTWARE.
 // Implement TTI stencil using formulation from Devito project.
 // TODO: provide a more readable TTI formulation.
 
-// This macro blocks the operator overloads in the API.
-// This is temporary until the "internal DSL" gets completely
-// replaced by the APIs.
-#define USE_INTERNAL_DSL
-
 #include "Soln.hpp"
 
 class TTIStencil:public StencilRadiusBase


### PR DESCRIPTION
…hpp stencil files to .cpp.