### PR TITLE
Fix bug in DSL by changing equality operator

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
-*Backward-compatibility notices:*
-* Version 2.11.01 changed the plain-text format of some of the performance data in the test-utility output. Specifically, some leading spaces were added, SI multipliers for values < 1 were added, and the phrase "time in" no longer appears before each time breakdown. This may affect users who parse the output to collect stats.
+#### Backward-compatibility notices:
+* Version 2.12.00 removed the long-deprecated '==' operator for asserting equality between a grid point and an equation. Use 'EQUALS' instead.
+* Version 2.11.01 changed the plain-text format of some of the performance data in the test-utility output. Specifically, some leading spaces were added, SI multipliers for values < 1 were added, and the phrase "time in" no longer appears before each time breakdown. This may affect some user programs that parse the output to collect stats.
 * Version 2.10.00 changed the location of temporary files created during the build process. This will not affect most users, although you may need to manually remove old `src/compiler/gen` and `src/kernel/gen` directories.
 * Version 2.09.00 changed the location of stencils in the internal DSL from `.hpp` to `.cpp` files. See the notes in https://github.com/intel/yask/releases/tag/v2.09.00 if you have any new or modified code in `src/stencils`.
 
@@ -41,9 +42,11 @@ YASK contains a domain-specific compiler to convert scalar stencil code to SIMD-
     * The `indent` or `gindent` utility, used automatically during the build process
       to make the generated code easier for humans to read.
       You'll get a warning when running `make` if one of these doesn't exist.
+      Everything will still work, but the generated code will be difficult to read.
+      Reading the generated code is only necessary for debug or curiosity.
     * SWIG (3.0.12 or later),
       http://www.swig.org, for creating the Python interface.
-    * Python 2 (2.7.5 or later) or 3 (3.6.1 or later),
+    * Python 2 (2.7.5 or later) or 3 (3.6.1 or later recommended),
       https://www.python.org/downloads, for creating and using the Python interface.
     * Doxygen (1.8.11 or later),
       http://doxygen.org, for creating updated API documentation.

--- a/src/common/common_utils.cpp
+++ b/src/common/common_utils.cpp
@@ -41,7 +41,7 @@ namespace yask {
     // for numbers above 9 (at least up to 99).
 
     // Format: "major.minor.patch".
-    const string version = "2.11.03";
+    const string version = "2.12.00";
 
     string yask_get_version_string() {
         return version;

--- a/src/compiler/lib/Expr.cpp
+++ b/src/compiler/lib/Expr.cpp
@@ -451,6 +451,16 @@ namespace yask {
         return expr;
     }
 
+    // Unused operators.
+    EqualsExprPtr operator BAD_OPER1(GridPointPtr gpp, const NumExprPtr rhs) {
+        THROW_YASK_EXCEPTION("Error: operator '==' is not allowed on a grid point;"
+                             " use 'EQUALS' to assert equality between a grid point (LHS)"
+                             " and an equation (RHS)");
+    }
+    EqualsExprPtr operator BAD_OPER1(GridPointPtr gpp, double rhs) {
+        return gpp EQUALS_OPER constNum(rhs);
+    }
+    
     // Define the value of a grid point.
     // Add this equation to the list of eqs for this stencil.
     EqualsExprPtr operator EQUALS_OPER(GridPointPtr gpp, const NumExprPtr rhs) {
@@ -478,6 +488,11 @@ namespace yask {
     }
     EqualsExprPtr operator EQUALS_OPER(GridPointPtr gpp, double rhs) {
         return gpp EQUALS_OPER constNum(rhs);
+    }
+    EqualsExprPtr operator EQUALS_OPER(GridPointPtr gpp, GridPointPtr rhs) {
+        auto p = dynamic_pointer_cast<NumExpr>(rhs);
+        assert(p);
+        return gpp EQUALS_OPER p;
     }
 
     // Visitor acceptors.
@@ -593,6 +608,7 @@ namespace yask {
             auto dim = dims.at(i);
             auto dname = dim->getName();
             auto arg = args.at(i);
+            assert(arg);
 #ifdef DEBUG_GP
             cout << " Arg " << arg->makeQuotedStr() <<
                 " at dim '" << dname << "'\n";

--- a/src/compiler/lib/Expr.hpp
+++ b/src/compiler/lib/Expr.hpp
@@ -954,13 +954,6 @@ namespace yask {
         }
     };
 
-    // A conditional evaluation.
-    // We use an otherwise unneeded binary operator that has a low priority.
-    // See http://en.cppreference.com/w/cpp/language/operator_precedence.
-#define IF_OPER ^=
-    EqualsExprPtr operator IF_OPER(EqualsExprPtr expr, const BoolExprPtr cond);
-#define IF IF_OPER
-
     ///// The following are operators and functions used in stencil expressions.
 
     // Various unary operators.
@@ -991,13 +984,31 @@ namespace yask {
     void operator/=(NumExprPtr& lhs, const NumExprPtr rhs);
     void operator/=(NumExprPtr& lhs, double rhs);
 
-    // The '==' operator used for defining a grid value.
-#define EQUALS_OPER ==
+    // A conditional evaluation.
+    // We use an otherwise unneeded binary operator that has a low priority.
+    // See http://en.cppreference.com/w/cpp/language/operator_precedence.
+#define IF_OPER ^=
+    EqualsExprPtr operator IF_OPER(EqualsExprPtr expr, const BoolExprPtr cond);
+#define IF IF_OPER
+
+    // The operator used for defining a grid value.
+    // We use an otherwise unneeded binary operator that has a lower priority
+    // than the math ops and a higher priority than the IF_OPER.
+    // See http://en.cppreference.com/w/cpp/language/operator_precedence.
+    // This should not be an operator that is defined for shared pointers.
+    // See https://en.cppreference.com/w/cpp/memory/shared_ptr.
+#define EQUALS_OPER <<
     EqualsExprPtr operator EQUALS_OPER(GridPointPtr gpp, const NumExprPtr rhs);
+    EqualsExprPtr operator EQUALS_OPER(GridPointPtr gpp, const GridPointPtr rhs);
     EqualsExprPtr operator EQUALS_OPER(GridPointPtr gpp, double rhs);
 #define EQUALS EQUALS_OPER
 #define IS_EQUIV_TO EQUALS_OPER
 #define IS_EQUIVALENT_TO EQUALS_OPER
+
+    // Catch use of the old '==' operator.
+#define BAD_OPER1 ==
+    EqualsExprPtr operator BAD_OPER1(GridPointPtr gpp, const NumExprPtr rhs);
+    EqualsExprPtr operator BAD_OPER1(GridPointPtr gpp, double rhs);
 
     // Binary numerical-to-boolean operators.
     // Must provide explicit IndexExprPtr operands to keep compiler from

--- a/src/stencils/FSGElastic2Stencil.cpp
+++ b/src/stencils/FSGElastic2Stencil.cpp
@@ -24,7 +24,9 @@ IN THE SOFTWARE.
 *****************************************************************************/
 
 // Stencil equations for FSG elastic numerics.
-// Contributed by Albert Farres from the Barcelona Supercomputing Center
+// Contributed by Albert Farres from the Barcelona Supercomputing Center.
+// This version varies from the original by grouping related grids into
+// larger grids with an added dimension.
 
 #include "Soln.hpp"
 #include "ElasticStencil/Elastic2Stencil.hpp"

--- a/src/stencils/FSGElasticStencil.cpp
+++ b/src/stencils/FSGElasticStencil.cpp
@@ -24,7 +24,7 @@ IN THE SOFTWARE.
 *****************************************************************************/
 
 // Stencil equations for FSG elastic numerics.
-// Contributed by Albert Farres from the Barcelona Supercomputing Center
+// Contributed by Albert Farres from the Barcelona Supercomputing Center.
 
 #include "Soln.hpp"
 #include "ElasticStencil/ElasticStencil.hpp"
@@ -493,7 +493,6 @@ namespace fsg {
         }
 
     };
-
 
     struct FSGElasticStencil : public FSGElasticStencilBase {
         FSGElasticStencil(StencilList& stencils) :

--- a/src/stencils/SSGElastic2Stencil.cpp
+++ b/src/stencils/SSGElastic2Stencil.cpp
@@ -24,6 +24,9 @@ IN THE SOFTWARE.
 *****************************************************************************/
 
 // Stencil equations for SSG elastic numerics.
+// Contributed by Albert Farres from the Barcelona Supercomputing Center.
+// This version varies from the original by grouping related grids into
+// larger grids with an added dimension.
 
 #include "ElasticStencil/Elastic2Stencil.hpp"
 
@@ -102,7 +105,7 @@ public:
         GridValue next_s = s(t, x, y, z, sidx) + ((vta + vtb) * lcoeff) * delta_t;
 
         // define the value at t+1.
-        s(t+1, x, y, z, sidx) == next_s;
+        s(t+1, x, y, z, sidx) EQUALS next_s;
     }
     template<typename N, typename DA, typename SA, typename DB, typename SB>
     void define_str(GridIndex t, GridIndex x, GridIndex y, GridIndex z,
@@ -132,9 +135,9 @@ public:
             + ilambdamu2 * vtz * delta_t;
 
         // define the value at t+1.
-        s(t+1, x, y, z, S_TL_XX) == next_xx;
-        s(t+1, x, y, z, S_TL_YY) == next_yy;
-        s(t+1, x, y, z, S_TL_ZZ) == next_zz;
+        s(t+1, x, y, z, S_TL_XX) EQUALS next_xx;
+        s(t+1, x, y, z, S_TL_YY) EQUALS next_yy;
+        s(t+1, x, y, z, S_TL_ZZ) EQUALS next_zz;
     }
 
     // Call all the define_* functions.

--- a/src/stencils/SSGElasticStencil.cpp
+++ b/src/stencils/SSGElasticStencil.cpp
@@ -24,6 +24,7 @@ IN THE SOFTWARE.
 *****************************************************************************/
 
 // Stencil equations for SSG elastic numerics.
+// Contributed by Albert Farres from the Barcelona Supercomputing Center.
 
 #include "ElasticStencil/ElasticStencil.hpp"
 
@@ -107,7 +108,7 @@ public:
         GridValue next_s = s(t, x, y, z) + ((vta + vtb) * lcoeff) * delta_t;
 
         // define the value at t+1.
-        s(t+1, x, y, z) == next_s;
+        s(t+1, x, y, z) EQUALS next_s;
     }
 
     void define_str_TL(GridIndex t, GridIndex x, GridIndex y, GridIndex z )
@@ -131,9 +132,9 @@ public:
             + ilambdamu2 * vtz * delta_t;
 
         // define the value at t+1.
-        s_tl_xx(t+1, x, y, z) == next_xx;
-        s_tl_yy(t+1, x, y, z) == next_yy;
-        s_tl_zz(t+1, x, y, z) == next_zz;
+        s_tl_xx(t+1, x, y, z) EQUALS next_xx;
+        s_tl_yy(t+1, x, y, z) EQUALS next_yy;
+        s_tl_zz(t+1, x, y, z) EQUALS next_zz;
     }
 
     // Call all the define_* functions.


### PR DESCRIPTION
Using '==' didn't allow copy equation, e.g., 'u(t,x) == v(t,x)'.